### PR TITLE
Add script which allow to test app on external devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev-public": "vite --host",
     "build": "run-p type-check build-only && cp -r CNAME dist/CNAME",
     "preview": "vite preview",
     "build-only": "vite build",


### PR DESCRIPTION
With this PR, it will be easier to test app on external devices in network. For now `npm run dev` doesn't allow to pass any flags and/or required to remember how to open vite to the public. With this script it will be faster to do from CLI or for ex. VS Code (because it automatically fetch all scripts from `package.json`)