### PR TITLE
Improve save size with compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "adventurers-guild",
-  "version": "0.14.0",
+  "version": "0.15.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adventurers-guild",
-      "version": "0.14.0",
+      "version": "0.15.4",
       "dependencies": {
         "@vueuse/components": "^9.13.0",
+        "pako": "^2.1.0",
         "sass": "^1.66.1",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       },
       "devDependencies": {
         "@types/node": "^18.17.6",
+        "@types/pako": "^2.0.3",
         "@vitejs/plugin-vue": "^4.3.1",
         "@vue/tsconfig": "^0.4.0",
         "eslint": "^8.47.0",
@@ -531,6 +533,13 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
       "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
+      "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.16",
@@ -2649,6 +2658,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3825,6 +3840,12 @@
       "version": "18.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
       "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
+      "dev": true
+    },
+    "@types/pako": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
+      "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
       "dev": true
     },
     "@types/web-bluetooth": {
@@ -5384,6 +5405,11 @@
       "requires": {
         "p-limit": "^3.0.2"
       }
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   },
   "dependencies": {
     "@vueuse/components": "^9.13.0",
+    "pako": "^2.1.0",
     "sass": "^1.66.1",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"
   },
   "devDependencies": {
     "@types/node": "^18.17.6",
+    "@types/pako": "^2.0.3",
     "@vitejs/plugin-vue": "^4.3.1",
     "@vue/tsconfig": "^0.4.0",
     "eslint": "^8.47.0",


### PR DESCRIPTION
Introducing a new save manager using ```pako```.

### Export save
- Compress the save from localStorage using ```pako.deflate()``` into an array of bytes.
- Encode the array into a string using base64.

### Import save
- Turn the pasted save into an array of bytes.
- Decompress the array of bytes using ```pako.inflate()``` and turn it into a save.

### Result
- My save with 12K characters turned into 2K characters.